### PR TITLE
名刺作成ボタンを緑色に変更

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -33,3 +33,16 @@
  	left: 50%;
  	transform: translate(-50%, -50%);
 }
+
+.actions > .btn.btn-success {
+  font-weight: bold;
+  background-color: #eff3f6;
+  background-image: linear-gradient(-180deg,#34d058,#28a745 90%);
+}
+
+.actions > .btn.btn-success:hover {
+  background-color: #269f42;
+  background-image: linear-gradient(-180deg,#2fcb53,#269f42 90%);
+  background-position: -.5em;
+  border-color: rgba(27,31,35,.5);
+}

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -33,7 +33,7 @@
   </div>
 
   <div id="submit" class="actions">
-    <%= form.submit "作成する", data: { disable_with: "名刺作成中…" }, class: "btn btn-light border" %>
+    <%= form.submit "作成する", data: { disable_with: "作成中…" }, class: "btn btn-success" %>
   </div>
 
   <div id="loading"></div>


### PR DESCRIPTION
Issue: https://github.com/matt-note/it-benkyoukai-meishi-generator/issues/158

## PRの理由・目的
名刺作成ボタンは白色で作っていたが、GitHubのボタンが緑色のため、名刺作成作成ボタンを緑色にしたくなったため。ボタンを緑色にしたことによって、GitHubっぽさを表現できるようになった。

## やったこと
+ 名刺作成ボタンを緑色にするCSSを追加。
+ Developer tool で GitHub の CSS を参考にした。
