### PR TITLE
エラーメッセージにスタイリングを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'image_processing'
 gem 'friendly_id', '~> 5.2.4'
 gem 'webpacker', require: false
 gem "google-cloud-storage", require: false
+gem "jquery-rails"
 
 # gem 'mini_magick', '~> 4.8'
 # gem 'mini_racer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,10 @@ GEM
       ruby-vips (>= 2.0.13, < 3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
+    jquery-rails (4.3.5)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     jwt (2.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -262,6 +266,7 @@ DEPENDENCIES
   google-cloud-storage
   image_processing
   jbuilder (~> 2.5)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   prawn

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,5 +13,7 @@
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
+//= require jquery3
+//= require jquery_ujs
 //= require bootstrap.min
 //= require_tree .

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>GithubMeishiGenerator</title>
+    <title>IT勉強会用 名刺ジェネレーター</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -12,7 +12,8 @@
   <body>
     <div class="container my-4">
       <div class="mx-auto" style="width: 680px">
-        <h1 class="mb-5">IT勉強会用 名刺ジェネレーター</h1>
+        <h1 class="mb-1 h2">IT勉強会用 名刺ジェネレーター</h1>
+        <hr class="mb-3">
         <%= yield %>
       </div>
     </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,15 +1,16 @@
 <%= form_with(model: user, local: true, id: "meishi-form") do |form| %>
   <% if user.errors.any? %>
-    <div id="error_explanation">
-      <ul>
+    <div id="error_explanation" class="alert alert-dismissible alert-danger">
+      <ul class="m-0">
       <% user.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>
       </ul>
+      <button type="button" class="close" data-dismiss="alert">×</button>
     </div>
   <% end %>
 
-  <div class="form-group row">
+  <div class="form-group row mt-4">
     <div class="col-md-3 col-form-label">
       <%= form.label :login %><span class="text-danger">*</span>
     </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -110,7 +110,7 @@ ja:
     format: "%{attribute}%{message}"
     messages:
       accepted: を受諾してください
-      blank: を入力してください
+      blank: を入力してください。
       confirmation: と%{attribute}の入力が一致しません
       empty: を入力してください
       equal_to: は%{count}にしてください
@@ -128,9 +128,9 @@ ja:
       odd: は奇数にしてください
       other_than: は%{count}以外の値にしてください
       present: は入力しないでください
-      required: を入力してください
+      required: を入力してください。
       taken: はすでに存在します
-      too_long: は%{count}文字以内で入力してください
+      too_long: は%{count}文字以内で入力してください。
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
     template:


### PR DESCRIPTION
Issue: https://github.com/matt-note/it-benkyoukai-meishi-generator/issues/145

## PRの理由・目的
エラーメッセージにスタイリングしていなかったため、アラートのスタイリングを追加した。

## やったこと
* エラーメッセージにスタイリングを追加。
+ jquery-rails が入ってなかったので、追加。
+ 全体的にスタイリングを調整。
