### PR TITLE
Procfileを追加

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rails server -p $PORT


### PR DESCRIPTION
Issue: https://github.com/matt-note/it-benkyoukai-meishi-generator/issues/156

## PRの理由・目的
Heroku のデプロイエラーを解消するために Procfile を追加。
参考: https://help.heroku.com/W23OAFGK/why-am-i-seeing-couldn-t-find-that-process-type-when-trying-to-scale-dynos

## やったこと
+ Procfile を追加