### PR TITLE
エラー「bundle: command not found」に対処

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rails server -p $PORT
+web: bin/rails server -p $PORT


### PR DESCRIPTION
Issue: https://github.com/matt-note/it-benkyoukai-meishi-generator/issues/156

## PRの理由・目的
Heroku にデプロイしたら、「bundle: command not found」というエラーメッセージが表示されたため。

## やったこと
+ `bundle exec rails` を `bin/rails` に変更。
