### PR TITLE
ImageMagickの設定を追加

### DIFF
--- a/.magick/policy.xml
+++ b/.magick/policy.xml
@@ -1,0 +1,1 @@
+<policy domain="delegate" rights="read" pattern="HTTPS" />

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: rails server -p $PORT
+web: bin/rails server -p $PORT

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,9 @@
   名刺原稿をダウンロードする
 <% end %>
 
-<%= link_to "#", class: "btn btn-success d-block mb-3 w-50" do %>
+<hr>
+
+<%= link_to "#", class: "btn btn-success d-block mt-4 mb-3 w-50" do %>
   ラクスルに入稿する（サンプルのボタン）
 <% end %>
 

--- a/bin/set_heroku_variables.sh
+++ b/bin/set_heroku_variables.sh
@@ -4,3 +4,4 @@
 # bash bin/set_heroku_variables.sh
 heroku config:set RAILS_MASTER_KEY="$(< config/master.key)"
 heroku config:set GOOGLE_APPLICATION_CREDENTIALS="$(< config/secrets/it-benkyoukai-meishi.json)"
+heroku config:set MAGICK_CONFIGURE_PATH="/app/.magick/:/etc/ImageMagick-6/"


### PR DESCRIPTION
Issue: https://github.com/matt-note/it-benkyoukai-meishi-generator/issues/156

## PRの理由・目的
Herokuでアプリがエラーになる理由が ImageMagick の設定にあることがわかった。ImageMagick の設定を一部上書きして、エラーを修正できるか試してみる。

## やったこと
+ .magick ディレクトリを作成。
+ policy.xml ファイルで設定を上書き。