### PR TITLE
README.mdにオペレーターチェック入稿のリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
 <img src="https://user-images.githubusercontent.com/39484102/62019713-117fb300-b1fb-11e9-9727-a54adb448401.png" width="400"/> | <img src="https://user-images.githubusercontent.com/39484102/62019716-13e20d00-b1fb-11e9-9f28-ce125a292ae1.png" width="400"/>
 
 ## 入稿結果
-作成したPDFは、ラクスルの『**オペレーターチェック入稿**』で入稿することができます。 <br>
+作成したPDFは、ラクスルの『**[オペレーターチェック入稿](https://raksul.com/guide/submit-data/#operator-check)**』で入稿することができます。
 <kbd>
 ![Screenshot from 2019-07-28 20-06-05](https://user-images.githubusercontent.com/39484102/62019473-f3fe1980-b1f9-11e9-9c50-b22184aa5630.png)
 </kbd>
 
 ## 参考
-以下のものをデザインの参考にしました。
+以下のものを名刺デザインの参考にしました。
 
 スティーブ・ジョブズの名刺 | Google社の名刺
 ---- | ----


### PR DESCRIPTION
## PRの理由・目的
ラクスルの「オペレーターチェック入稿」について、ラクスルのURLを追加して、理解できるようにしたい。
