### PR TITLE
印刷可能なPDFをダウンロードできるように修正した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:18.04
+LABEL Name=press-ready Version=0.1.0
+
+RUN apt-get update -qq && apt-get install -yqq curl
+
+# Xpdf, Ghostscript, ImageMagick
+RUN apt-get update -qq && apt-get install -yqq xpdf ghostscript imagemagick
+
+# NodeJS
+RUN apt-get update -qq && apt-get install -yqq nodejs npm && npm install n -g && n 11.13.0
+RUN npm install -g yarn
+
+# AWS
+RUN apt-get update -qq && apt-get install -yqq python3-pip && pip3 install awscli
+
+WORKDIR /app
+COPY assets/* /app/assets/
+COPY package.json yarn.lock /app/
+RUN yarn install --only=production
+COPY src/* /app/src/
+
+WORKDIR /workdir
+ENTRYPOINT [ "/app/src/cli.js" ]
+
+# wkhtmltopdf 0.12.5
+# RUN apt-get update && apt-get install -y gdebi
+# RUN curl -sL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb -o wkhtmltox.deb
+# RUN gdebi --n wkhtmltox.deb && rm wkhtmltox.deb
+
+# Chrome / Puppeteer
+# RUN apt-get update && apt-get install -y libasound2-dev libxss-dev

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,16 +5,19 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find_by(public_uid: params[:id])
+
     respond_to do |format|
       format.html
       format.pdf do
-        send_data(MeishiPDF.new(@user).render,
+        send_data(File.read(@user.printable_pdf_path),
                   filename: "meishi.pdf",
                   type: "application/pdf")
 
         File.delete(@user.avatar_path)
         File.delete(@user.github_qrcode_path)
         File.delete(@user.twitter_qrcode_path)
+        File.delete(@user.preview_pdf_path)
+        File.delete(@user.printable_pdf_path)
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,12 @@ class User < ApplicationRecord
   def twitter_qrcode_path
     Rails.root.join("tmp/#{login}-twitter-qrcode.png").to_s
   end
+
+  def preview_pdf_path
+    "./tmp/#{public_uid}.pdf"
+  end
+
+  def printable_pdf_path
+    "./tmp/printable-#{public_uid}.pdf"
+  end
 end

--- a/app/models/user_callbacks.rb
+++ b/app/models/user_callbacks.rb
@@ -2,6 +2,7 @@ class UserCallbacks
   def after_create(user)
     fetch_images(user)
     fetch_github_name(user)
+    create_printable_pdf(user)
   end
 
   private
@@ -66,5 +67,11 @@ class UserCallbacks
         user.name = json["name"]
       end
       user.update(name: user.name)
+    end
+
+    def create_printable_pdf(user)
+      pdf = MeishiPDF.new(user)
+      pdf.render_file(user.preview_pdf_path)
+      system("docker run -it -v $PWD:/workdir vibranthq/press-ready --input #{user.preview_pdf_path} --output #{user.printable_pdf_path}")
     end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -78,7 +78,12 @@
 <img width="680" class="border rounded p-2" src="https://user-images.githubusercontent.com/39484102/62372682-0fa74e00-b573-11e9-8878-b442a779e62b.png" alt="PDFを入稿">
 
 <p class="mt-5">
-  PDFを確認するか選択して、入稿します。
+  入稿データ形式の選択でPDFデータを選択します。
+</p>
+<img width="680" class="border rounded p-2" src="https://user-images.githubusercontent.com/39484102/63242574-c6edd580-c292-11e9-9726-42b641f672c5.png" alt="入稿データ形式">
+
+<p class="mt-5">
+  オペーレーターチェック後にPDFを確認するか選択して、入稿します。
 </p>
 <img width="680" class="border rounded p-2" src="https://user-images.githubusercontent.com/39484102/63182078-9d635d00-c08c-11e9-84b3-7a24589f7b71.png" alt="PDFを入稿">
 

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    pdf: Dockerfile


### PR DESCRIPTION
Issue: #250 

## PRの理由・目的
ラクスルにPDFデータを入稿したら、「プレビュー用のPDFのため印刷できない」というメールが届いてしまった。そこでWeb閲覧用のPDFではなくて、紙への印刷用のPDFを作成しなければならくなってしまった。

調べたところ、[press-ready](https://github.com/vibranthq/press-ready/blob/master/README.ja.md) で、印刷用のPDFを作成できることがわかった。これを使ってみたところ、ローカルで印刷用のPDFを作成することができた。Dockerを使っているので、本番環境ですぐにうまくいくかはわからないが、エラーが出た場合は、エラー文を参考にして対処していくことにする。
