### PR TITLE
Dockerfileを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN yarn install --only=production
 COPY src/* /app/src/
 
 WORKDIR /workdir
-ENTRYPOINT [ "/app/src/cli.js" ]
+CMD [ "/app/src/cli.js" ]
 
 # wkhtmltopdf 0.12.5
 # RUN apt-get update && apt-get install -y gdebi


### PR DESCRIPTION
Issue: #252 

## PRの理由・目的
Herokuにデプロイしてみたが、エラーが発生した。エラー文で検索したところ、`Dockerfile`の`ENTRYPOINT`を`CMD`にすれば修正できるという記事を見つけたので、これを試してみる。

https://stackoverflow.com/questions/55913408/no-command-specified-for-process-type-web-on-heroku
