### PR TITLE
印刷用PDF部分を普通のPDFに戻すように修正した

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,15 +9,19 @@ class UsersController < ApplicationController
     respond_to do |format|
       format.html
       format.pdf do
-        send_data(File.read(@user.printable_pdf_path),
+        send_data(MeishiPDF.new(@user).render,
                   filename: "meishi.pdf",
                   type: "application/pdf")
+
+        # send_data(File.read(@user.printable_pdf_path),
+        #           filename: "meishi.pdf",
+        #           type: "application/pdf")
 
         File.delete(@user.avatar_path)
         File.delete(@user.github_qrcode_path)
         File.delete(@user.twitter_qrcode_path)
-        File.delete(@user.preview_pdf_path)
-        File.delete(@user.printable_pdf_path)
+        # File.delete(@user.preview_pdf_path)
+        # File.delete(@user.printable_pdf_path)
       end
     end
   end

--- a/app/models/user_callbacks.rb
+++ b/app/models/user_callbacks.rb
@@ -2,7 +2,7 @@ class UserCallbacks
   def after_create(user)
     fetch_images(user)
     fetch_github_name(user)
-    create_printable_pdf(user)
+    # create_printable_pdf(user)
   end
 
   private
@@ -69,9 +69,8 @@ class UserCallbacks
       user.update(name: user.name)
     end
 
-    def create_printable_pdf(user)
-      pdf = MeishiPDF.new(user)
-      pdf.render_file(user.preview_pdf_path)
-      system("docker run -it -v $PWD:/workdir vibranthq/press-ready --input #{user.preview_pdf_path} --output #{user.printable_pdf_path}")
-    end
+    # def create_printable_pdf(user)
+    #   pdf = MeishiPDF.new(user)
+    #   pdf.render_file(user.preview_pdf_path)
+    # end
 end


### PR DESCRIPTION
## PRの理由・目的
press-ready を使っていた部分を削除したので、印刷用PDFでない普通のPDFに変更して、トンボのデザインを修正して、ラクスルに入稿することを試してみたい。
