### PR TITLE
Aboutページでフォントサイズの説明文を削除した

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,10 +13,6 @@ class UsersController < ApplicationController
                   filename: "meishi.pdf",
                   type: "application/pdf")
 
-        # send_data(MeishiPDF.new(@user).render,
-        #           filename: "meishi.pdf",
-        #           type: "application/pdf")
-
         File.delete(@user.avatar_path)
         File.delete(@user.github_qrcode_path)
         File.delete(@user.twitter_qrcode_path)

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -65,27 +65,6 @@
     </p>
     </div>
 
-    <div class="card border-danger mt-3 p-3">
-      <p>
-        <strong>
-          同じフォントサイズでも、違うフォントサイズに見えてしまいます
-        </strong>
-      </p>
-      <div class="row">
-        <div class="col-md-7">
-          <p>
-            右の名刺原稿を見ると、GitHubアカウントとTwitterアカウントのフォントサイズが違っているように見えます。
-            しかし、両者は同じフォントを使っていて、同じフォントサイズを使っています。印刷をすると、両者は同じフォントで同じフォントサイズで印刷されます。
-          </p>
-        </div>
-        <div class="col-md-5">
-          <img class="border" width="240" src="https://user-images.githubusercontent.com/39484102/62113567-ceebd280-b2ef-11e9-9f5b-d7eb013e54e9.png" alt="">
-        </div>
-      </div>
-      <small>実際の名刺</small>
-      <img width="640" src="https://user-images.githubusercontent.com/39484102/62444557-c9333880-b798-11e9-98bc-a487885390a3.jpg" alt="実際の名刺">
-    </div>
-
     <div class="card border-danger p-3 mt-3 mb-5">
       <p>
         <strong>GitHub APIの利用制限について</strong>


### PR DESCRIPTION
Issue: #268 

## PRの理由・目的
press-ready を使うことで、これまで問題になっていた「同じフォントサイズだけど違うように見えてしまう」問題を解消することができた。
これによって「同じフォントサイズだけど違うように見えてしまう」ことの説明文を削除できるようになった。