### PR TITLE
package.jsonからdevDependencyを削除した。

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,5 @@
     "mustache": "^3.0.1",
     "yargs": "^13.3.0"
   },
-  "license": "MIT",
-  "private": true,
-  "devDependencies": {
-    "debug": "^4.1.1"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
Issue: #276 

## PRの理由・目的
Herokuでエラーが発生したので、ログを頼りにして、package.jsonから不要だと思ったパッケージを削除した。