### PR TITLE
press-readyを使わないように修正した

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,15 +9,19 @@ class UsersController < ApplicationController
     respond_to do |format|
       format.html
       format.pdf do
-        send_data(File.read(@user.printable_pdf_path),
+        send_data(MeishiPDF.new(@user).render,
                   filename: "meishi.pdf",
                   type: "application/pdf")
+                  
+        # send_data(File.read(@user.printable_pdf_path),
+        #           filename: "meishi.pdf",
+        #           type: "application/pdf")
 
         File.delete(@user.avatar_path)
         File.delete(@user.github_qrcode_path)
         File.delete(@user.twitter_qrcode_path)
-        File.delete(@user.normal_pdf_path)
-        File.delete(@user.printable_pdf_path)
+        # File.delete(@user.normal_pdf_path)
+        # File.delete(@user.printable_pdf_path)
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,11 +23,11 @@ class User < ApplicationRecord
     Rails.root.join("tmp/#{login}-twitter-qrcode.png").to_s
   end
 
-  def normal_pdf_path
-    Rails.root.join("tmp/#{public_uid}.pdf").to_s
-  end
-
-  def printable_pdf_path
-    Rails.root.join("tmp/printable-#{public_uid}.pdf").to_s
-  end
+  # def normal_pdf_path
+  #   Rails.root.join("tmp/#{public_uid}.pdf").to_s
+  # end
+  #
+  # def printable_pdf_path
+  #   Rails.root.join("tmp/printable-#{public_uid}.pdf").to_s
+  # end
 end

--- a/app/models/user_callbacks.rb
+++ b/app/models/user_callbacks.rb
@@ -2,7 +2,7 @@ class UserCallbacks
   def after_create(user)
     fetch_images(user)
     fetch_github_name(user)
-    create_printable_pdf(user)
+    # create_printable_pdf(user)
   end
 
   private
@@ -69,9 +69,9 @@ class UserCallbacks
       user.update(name: user.name)
     end
 
-    def create_printable_pdf(user)
-      pdf = MeishiPDF.new(user)
-      pdf.render_file(user.normal_pdf_path)
-      system("node #{Rails.root.join("src/cli.js").to_s} --input #{user.normal_pdf_path} --output #{user.printable_pdf_path}")
-    end
+    # def create_printable_pdf(user)
+    #   pdf = MeishiPDF.new(user)
+    #   pdf.render_file(user.normal_pdf_path)
+    #   system("node #{Rails.root.join("src/cli.js").to_s} --input #{user.normal_pdf_path} --output #{user.printable_pdf_path}")
+    # end
 end


### PR DESCRIPTION
## PRの理由・目的
Heroku環境で press-ready を使おうとしたら、エラーで進めなくなってしまったので、press-ready を使う部分をコメントアウトした。
普通のWeb閲覧用のPDFを出力するように修正した。