### PR TITLE
名刺の表面の画像をPDF/X-1aのものに修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 表 | 裏
 ---- | ----
-<img src="https://user-images.githubusercontent.com/39484102/63570735-19900000-c5b9-11e9-9550-825e7cf573ba.png" width="400"/> | <img src="https://user-images.githubusercontent.com/39484102/63570760-2f9dc080-c5b9-11e9-982c-593c027744bd.png" width="400"/>
+<img src="https://user-images.githubusercontent.com/39484102/63944280-37bf9980-caac-11e9-938d-921a72d96b90.png" width="400"/> | <img src="https://user-images.githubusercontent.com/39484102/63570760-2f9dc080-c5b9-11e9-982c-593c027744bd.png" width="400"/>
 
 ## 入稿結果
 ![63570926-9ae79280-c5b9-11e9-8be0-ab8b14a85a49](https://user-images.githubusercontent.com/39484102/63602388-474d6700-c602-11e9-99a1-47a9cd8540cb.png)

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -21,7 +21,7 @@
         </p>
       </div>
       <div class="col-md-4">
-        <img class="border" width="200" src="https://user-images.githubusercontent.com/39484102/63515724-755d7900-c526-11e9-8425-7cefb936526d.png" alt="名刺の表">
+        <img class="border" width="200" src="https://user-images.githubusercontent.com/39484102/63944280-37bf9980-caac-11e9-938d-921a72d96b90.png" alt="名刺の表">
       </div>
     </div>
     <div class="row mt-3">


### PR DESCRIPTION
## PRの理由・目的
フォントサイズがバラバラの画像を使っていたので、正しいフォトサイズの画像に修正した。