### PR TITLE
ワークフローを実行するタイミングを変更

### DIFF
--- a/.github/workflows/rails-ci.yml
+++ b/.github/workflows/rails-ci.yml
@@ -1,6 +1,6 @@
 name: rails-ci
 
-on: push
+on: pull_request
 
 jobs:
   run-test:


### PR DESCRIPTION
Issue: #000

## PRの理由・目的
CIを実行するタイミングを、プルリクした時に変更した。`on: push`だと、トピックブランチを`master`ブランチにマージする時にもCIが動いたため。
