### PR TITLE
Fix meishi name output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'jquery-rails'
 gem 'meta-tags'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'prawn'
-gem 'public_uid'
 gem 'puma', '~> 3.11'
 gem 'rails', '~> 5.2.3'
 gem 'sass-rails', '~> 5.0'
@@ -23,6 +22,7 @@ gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 gem 'webpacker', require: false
 gem 'google-analytics-rails'
+gem 'upknit'
 
 # gem 'mini_magick', '~> 4.8'
 # gem 'mini_racer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,6 @@ GEM
     nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
-    orm_adapter (0.5.0)
     os (1.0.1)
     pdf-core (0.7.0)
     pg (1.1.4)
@@ -161,8 +160,6 @@ GEM
       pdf-core (~> 0.7.0)
       ttfunk (~> 1.5)
     public_suffix (3.1.1)
-    public_uid (1.3.1)
-      orm_adapter (~> 0.5)
     puma (3.12.1)
     rack (2.0.7)
     rack-proxy (0.6.5)
@@ -271,6 +268,8 @@ GEM
     uber (0.1.0)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    upknit (0.9.6)
+      rails (~> 5.1)
     vcr (5.0.0)
     web-console (3.7.0)
       actionview (>= 5.0)
@@ -315,7 +314,6 @@ DEPENDENCIES
   meta-tags
   pg (>= 0.18, < 2.0)
   prawn
-  public_uid
   puma (~> 3.11)
   rails (~> 5.2.3)
   rails_real_favicon
@@ -327,6 +325,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  upknit
   vcr
   web-console (>= 3.3.0)
   webdrivers

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find_by(public_uid: params[:id])
+    @user = User.find(params[:id])
 
     respond_to do |format|
       format.html

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,12 +7,6 @@ class User < ApplicationRecord
   validates :twitter_account, presence: true
   validates_with UserValidator
 
-  generate_public_uid generator: PublicUid::Generators::HexStringSecureRandom.new(20)
-
-  def to_param
-    public_uid
-  end
-
   def avatar_path
     Rails.root.join("tmp/#{login}.jpg").to_s
   end
@@ -26,10 +20,10 @@ class User < ApplicationRecord
   end
 
   def normal_pdf_path
-    Rails.root.join("tmp/#{public_uid}.pdf").to_s
+    Rails.root.join("tmp/#{id}.pdf").to_s
   end
 
   def printable_pdf_path
-    Rails.root.join("tmp/printable-#{public_uid}.pdf").to_s
+    Rails.root.join("tmp/printable-#{id}.pdf").to_s
   end
 end

--- a/app/models/user_callbacks.rb
+++ b/app/models/user_callbacks.rb
@@ -86,7 +86,8 @@ class UserCallbacks
   def create_printable_pdf(user)
     pdf = MeishiPDF.new(user)
     pdf.render_file(user.normal_pdf_path)
-    system("node #{Rails.root.join("src/cli.js").to_s} --input #{user.normal_pdf_path} --output #{user.printable_pdf_path}")
+    pdf.render_file(user.printable_pdf_path)
+    # system("node #{Rails.root.join("src/cli.js").to_s} --input #{user.normal_pdf_path} --output #{user.printable_pdf_path}")
   end
 
   def delete_images(user)

--- a/db/migrate/20190625121008_create_users.rb
+++ b/db/migrate/20190625121008_create_users.rb
@@ -2,11 +2,10 @@
 
 class CreateUsers < ActiveRecord::Migration[5.2]
   def change
-    create_table :users do |t|
+    create_table :users, id: :uuid do |t|
       t.string :name
       t.string :login, null: false
       t.string :twitter_account, null: false
-      t.string :public_uid, null: false, index: true, unique: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_625_121_008) do
-  # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+ActiveRecord::Schema.define(version: 2019_06_25_121008) do
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'name'
-    t.string 'login', null: false
-    t.string 'twitter_account', null: false
-    t.string 'public_uid', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['public_uid'], name: 'index_users_on_public_uid'
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
+  enable_extension "plpgsql"
+
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.string "login", null: false
+    t.string "twitter_account", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 end


### PR DESCRIPTION
## PRの理由・目的
プロダクション環境で、名刺の名前を表示できないエラーが発生していると報告を受けたため、このエラーに対処した。ただし、一時的に`press-ready`を使わないように設定して、このエラーを回避したため、後日`press-ready`を使えるように設定する。
